### PR TITLE
Align CLI strings and validation helpers with MCO1 requirements

### DIFF
--- a/mco1-bankfx-r/R/ui_screens.R
+++ b/mco1-bankfx-r/R/ui_screens.R
@@ -10,6 +10,44 @@ source("R/account.R")                                                        # r
 source("R/rates.R")                                                          # set_rate(), get_rate(), convert_amount()
 source("R/interest.R")                                                       # daily_interest(), simulate_interest()
 
+# Canonical currency labels (per spec screenshots) keyed by code for reuse.
+.currency_labels <- c(
+  PHP = "Philippine Peso (PHP)",
+  USD = "United States Dollar (USD)",
+  JPY = "Japanese Yen (JPY)",
+  GBP = "British Pound Sterling (GBP)",
+  EUR = "Euro (EUR)",
+  CNY = "Chinese Yuan Renminni (CNY)"
+)
+
+.print_currency_menu <- function(title = NULL) {                               # Shared printer for numbered currency menus.
+  if (!is.null(title)) cat(title, "\n", sep = "")                            # Optional section label (e.g., Source/Exchange).
+  idx <- seq_along(.currency_labels)                                           # Numeric indices 1..6.
+  for (i in idx) {                                                             # Print one line per currency exactly as spec.
+    cat(sprintf("[%d] %s\n", i, .currency_labels[i]))
+  }
+}
+
+.coerce_currency_selection <- function(input) {                                # Accept bracketed numbers or codes.
+  raw <- trimws(input)                                                         # Remove stray whitespace around the input.
+  raw <- gsub("[\t\r\n]", "", raw, perl = TRUE)                            # Strip control characters defensively.
+  raw <- gsub("[\[\]]", "", raw, perl = TRUE)                              # Allow entries like "[2]" from the spec transcript.
+  if (!nzchar(raw)) stop("Currency selection cannot be blank.", call. = FALSE)
+
+  # Try numeric index first (per spec prompt using option numbers).
+  idx <- suppressWarnings(as.integer(raw))
+  if (!is.na(idx) && idx >= 1 && idx <= length(.currency_labels)) {
+    return(names(.currency_labels)[idx])
+  }
+
+  # Fallback: treat as currency code and normalize via ensure_currency().
+  return(ensure_currency(raw))
+}
+
+.account_label <- function(state) {                                            # Friendly display for account holder name.
+  if (is.null(state$account$name)) "(not registered)" else state$account$name
+}
+
 # ────────────────────────────────────────────────────────────────────────────
 # Small local I/O helpers (parse/validate console input at the UI edge)
 # ────────────────────────────────────────────────────────────────────────────
@@ -40,7 +78,7 @@ source("R/interest.R")                                                       # d
 # Spec text: heading "Register Account Name" then prompt "Account Name: "
 # ────────────────────────────────────────────────────────────────────────────
 screen_register <- function(state) {
-  heading("Register Account Name")                                           # Visual section separator for readability.
+  cat("\nRegister Account Name\n")                                           # Exact heading per spec screenshot.
   name <- .read_line("Account Name: ")                                       # Exact prompt per spec.
   state <- register_account(state, name)                                     # Delegate validation & mutation to domain logic.
   cat("Registered: ", state$account$name, "\n", sep = "")                    # Confirm stored (trimmed) name to the user.
@@ -50,17 +88,18 @@ screen_register <- function(state) {
 # ────────────────────────────────────────────────────────────────────────────
 # Screen: Record Exchange Rate
 # Spec text: show currency choices; disallow changing PHP (base=1.00)
-# Prompts: "Select currency code:" then "Enter rate (PHP per 1 CODE): "
+# Prompts: "Select Foreign Currency:" then "Exchange Rate:" (per PDF transcript)
 # ────────────────────────────────────────────────────────────────────────────
 screen_record_rates <- function(state) {
-  heading("Record Exchange Rate")                                            # Section header matches deliverable screenshot.
-  cat("[1] PHP  [2] USD  [3] JPY  [4] GBP  [5] EUR  [6] CNY\n")              # Display the allowed set (informational).
-  code <- toupper(.read_line("Select currency code: "))                      # Read code; normalize case for UX.
+  cat("\nRecord Exchange Rate\n")                                            # Heading exactly as shown in the PDF.
+  .print_currency_menu()                                                     # Display numbered currency list.
+  choice <- .read_line("Select Foreign Currency: ")                          # Spec prompt (expects number or code).
+  code <- .coerce_currency_selection(choice)                                 # Allow numeric selection or code entry.
   if (code == "PHP") {                                                       # PHP base is immutable by spec.
     cat("PHP is fixed at 1.00.\n")                                           # Inform user; no state change.
     return(state)                                                            # Early exit: nothing to set.
   }
-  rate <- .read_number(paste0("Enter rate (PHP per 1 ", code, "): "))        # Ask for "PHP per 1 CODE"; parse as numeric.
+  rate <- .read_number("Exchange Rate: ")                                    # Prompt label per spec screenshot.
   state <- set_rate(state, code, rate)                                       # Delegate validation & write to domain logic.
   cat("Saved: 1 ", code, " = ", money(rate), " PHP\n", sep = "")             # Confirm persistence with 2-decimal echo.
   state                                                                      # Return updated state.
@@ -72,23 +111,27 @@ screen_record_rates <- function(state) {
 # Output : "Exchange Amount: <amount> <DST>"
 # ────────────────────────────────────────────────────────────────────────────
 screen_currency_exchange <- function(state) {
-  heading("Currency Exchange")                                               # Header matches spec.
-  src <- toupper(.read_line("Source Currency: "))                            # Source code (case-insensitive input).
-  dst <- toupper(.read_line("Target Currency: "))                            # Destination code.
-  amt <- .read_number("Amount: ")                                            # Amount to convert (double).
-  out <- convert_amount(state, amt, src, dst)                                # Use spec formula inside domain logic.
-  cat("Exchange Amount: ", money(out), " ", dst, "\n", sep = "")             # Print 2-decimal result with target code.
+  cat("\nForeign Currency Exchange\n")                                       # Heading per spec output page.
+  .print_currency_menu("Source Currency Option:")                            # List options before selecting source.
+  src <- .coerce_currency_selection(.read_line("Source Currency: "))         # Accept numeric or code input.
+  amt <- .read_number("Source Amount: ")                                     # Amount in source currency.
+  .print_currency_menu("Exchanged Currency Options:")                        # List options before selecting destination.
+  dst <- .coerce_currency_selection(.read_line("Exchange Currency: "))       # Accept numeric or code input.
+  out <- convert_amount(state, amt, src, dst)                                # Apply spec conversion formula.
+  cat("Exchange Amount: ", money(out), "\n", sep = "")                      # Display converted amount (2 decimals via money).
   state                                                                      # State unchanged but returned for API uniformity.
 }
 
 # ────────────────────────────────────────────────────────────────────────────
 # Screen: Deposit Amount
-# Prompts: "Currency (PHP/USD/JPY/GBP/EUR/CNY):", "Deposit Amount:"
+# Prompts: "Currency:", "Deposit Amount:" with account/balance context lines
 # Output : updated balance in PHP (2 decimals)
 # ────────────────────────────────────────────────────────────────────────────
 screen_deposit <- function(state) {
-  heading("Deposit Amount")                                                  # Section header for screenshot parity.
-  cur <- toupper(.read_line("Currency (PHP/USD/JPY/GBP/EUR/CNY): "))         # Currency to deposit in.
+  cat("\nDeposit Amount\n")                                                  # Heading matches PDF output.
+  cat("Account Name: ", .account_label(state), "\n", sep = "")               # Echo current account holder (if any).
+  cat("Current Balance: ", money(get_balance_php(state)), "\n", sep = "")     # Show balance before deposit (PHP).
+  cur <- .coerce_currency_selection(.read_line("Currency: "))                # Accept numeric menu choice or code.
   amt <- .read_number("Deposit Amount: ")                                    # Amount to deposit.
   state <- deposit(state, amt, cur)                                          # Domain logic: handles conversion & validation.
   cat("Updated Balance: ", money(get_balance_php(state)), " PHP\n", sep = "")# Show canonical balance after operation.
@@ -97,12 +140,14 @@ screen_deposit <- function(state) {
 
 # ────────────────────────────────────────────────────────────────────────────
 # Screen: Withdraw Amount
-# Prompts: "Currency (PHP/USD/JPY/GBP/EUR/CNY):", "Withdraw Amount:"
+# Prompts: "Currency:", "Withdraw Amount:" with account/balance context lines
 # Output : updated balance in PHP (2 decimals); errors on overdraft
 # ────────────────────────────────────────────────────────────────────────────
 screen_withdraw <- function(state) {
-  heading("Withdraw Amount")                                                 # Section header.
-  cur <- toupper(.read_line("Currency (PHP/USD/JPY/GBP/EUR/CNY): "))         # Currency to withdraw in.
+  cat("\nWithdraw Amount\n")                                                 # Heading matches PDF output.
+  cat("Account Name: ", .account_label(state), "\n", sep = "")               # Echo current account holder (if any).
+  cat("Current Balance: ", money(get_balance_php(state)), "\n", sep = "")     # Show balance before withdrawal (PHP).
+  cur <- .coerce_currency_selection(.read_line("Currency: "))               # Accept numeric menu choice or code.
   amt <- .read_number("Withdraw Amount: ")                                   # Amount to withdraw.
   state <- withdraw(state, amt, cur)                                         # Domain logic: FX conversion + overdraft guard.
   cat("Updated Balance: ", money(get_balance_php(state)), " PHP\n", sep = "")# Confirm new canonical balance.
@@ -115,21 +160,30 @@ screen_withdraw <- function(state) {
 # Output : ASCII table "Day | Interest | Balance" with 2-decimal formatting
 # ────────────────────────────────────────────────────────────────────────────
 screen_show_interest <- function(state) {
-  heading("Show Interest Amount")                                            # Section header per spec.
+  cat("\nShow Interest Amount\n")                                            # Section header per spec.
+  cat("Account Name: ", .account_label(state), "\n", sep = "")               # Provide context consistent with PDF output.
+  cat("Current Balance: ", money(get_balance_php(state)), "\n", sep = "")     # Show current balance before simulation.
+  cat("Currency: PHP\n")                                                     # Balance is always maintained in PHP.
+  cat("Interest Rate: ", money(state$annual_rate * 100, digits = 0), "%\n", sep = "") # Display 5% rate per spec.
   days <- .read_integer("Total Number of Days: ")                            # Integer day count (≥1 enforced downstream).
+  cat("Total Number of Days: ", days, " days\n", sep = "")                   # Echo input like the PDF transcript.
   tbl <- simulate_interest(                                                  # Generate compounded table from current balance.
     start_balance_php = get_balance_php(state),                              # Use canonical PHP balance as the principal.
     days = days,                                                             # Horizon provided by the user.
     annual_rate = state$annual_rate                                          # Global annual rate from state.
   )
 
-  # Print an aligned ASCII table using money() for 2-decimal display.
-  cat(sprintf("%-5s | %-10s | %-12s\n", "Day", "Interest", "Balance"))       # Column headers with fixed widths.
-  for (i in seq_len(nrow(tbl))) {                                            # Iterate rows to print formatted values.
-    cat(sprintf("%-5d | %-10s | %-12s\n",                                   # Fixed-width row with money()-formatted numbers.
-                tbl$day[i],
-                money(tbl$interest[i]),
-                money(tbl$balance[i])))
+  # Print table exactly as the PDF layout (pipes separating columns).
+  cat("Day | Interest | Balance |\n")
+  for (i in seq_len(nrow(tbl))) {
+    cat(
+      sprintf(
+        "%d | %s | %s |\n",
+        tbl$day[i],
+        money(tbl$interest[i]),
+        money(tbl$balance[i])
+      )
+    )
   }
   state                                                                      # State unchanged; function returns state for uniform API.
 }

--- a/mco1-bankfx-r/R/validation.R
+++ b/mco1-bankfx-r/R/validation.R
@@ -8,8 +8,8 @@
 # Helpers (tiny, pure functions used by the asserts)
 # ────────────────────────────────────────────────────────────────────
 .allowed_codes <- function() {                        # Get the canonical list of currency codes
-    if (exists("CURRENCY_CODES", inherits = TRUE))    # …prefer the constant from state.R if it's already loaded, 
-        get("CURRENT_CODES", inherits = TRUE)         # …so we never duplicate source of truth.
+    if (exists("CURRENCY_CODES", inherits = TRUE))    # …prefer the constant from state.R if it's already loaded,
+        get("CURRENCY_CODES", inherits = TRUE)        # …so we never duplicate source of truth.
     else                                              # Fallback in case validation.R is sourced before state.R:
         c("PHP", "USD", "JPY", "GBP", "EUR", "CNY")   # …still lets this file work independently in tests.
 }
@@ -71,5 +71,12 @@ assert_name <- function(name) {                                        # Validat
   invisible(TRUE)                                                      # OK.
 }
 
+
+
+ensure_currency <- function(code) {                                    # Normalize + validate currency code in one helper.
+  clean <- .sanitize_currency(code)                                    # Trim/uppercase for canonical form.
+  assert_currency(clean)                                               # Reuse guard to enforce allowed set.
+  clean                                                                # Return sanitized code for callers.
+}
 
 

--- a/mco1-bankfx-r/app/main.R
+++ b/mco1-bankfx-r/app/main.R
@@ -20,19 +20,15 @@ source("R/ui_screens.R")                                                        
 # ──────────────────────────────────────────────────────────────────────────────
 
 print_main_menu <- function() {                                                 # Prints the menu exactly as the spec shows.
-  cat("\n==============================\n")                                      # Visual separator (nice for screenshots).
-  cat("Main Menu\n")                                                            # Title line.
-  cat("==============================\n")                                         # Closing banner.
-  cat(                                                                          # Exact options (labels must match the spec).
-    "[1] Register Account Name\n",
-    "[2] Deposit Amount\n",
-    "[3] Withdraw Amount\n",
-    "[4] Currency Exchange\n",
-    "[5] Record Exchange Rates\n",
-    "[6] Show Interest Amount\n",
-    "[0] Exit\n",
-    sep = ""
-  )
+  cat("\nMain Menu\n")                                                        # Title line.
+  cat("Select Transaction:\n")                                                 # Subtitle per PDF output.
+  cat("[1] Register Account Name\n")
+  cat("[2] Deposit Amount\n")
+  cat("[3] Withdraw Amount\n")
+  cat("[4] Currency Exchange\n")
+  cat("[5] Record Exchange Rates\n")
+  cat("[6] Show Interest Computation\n")
+  cat("[0] Exit\n")
 }
 
 read_choice <- function() {                                                     # Reads one line from stdin for the menu pick.
@@ -41,7 +37,7 @@ read_choice <- function() {                                                     
 }
 
 ask_back_to_main_menu <- function() {                                           # Asks whether to loop back to the menu.
-  cat("\nBack to Main Menu (Y/N): ")                                            # Exact wording per spec.
+  cat("\nBack to the Main Menu (Y/N): ")                                        # Exact wording per spec (note "the").
   ans <- toupper(trimws(readLines(stdin(), n = 1)))                              # Normalize to uppercase.
   ans == "Y"                                                                     # TRUE to loop, FALSE to exit.
 }

--- a/mco1-bankfx-r/docs/screenshots/README.md
+++ b/mco1-bankfx-r/docs/screenshots/README.md
@@ -1,0 +1,3 @@
+# Screenshots Placeholder
+
+Place the required CLI screenshots for the MCO1 Banking and Currency Exchange Application in this folder. Each image should demonstrate the corresponding menu flow described in the specification (registration, deposit, withdraw, exchange rate entry, currency exchange, and interest computation).

--- a/mco1-bankfx-r/tests/test_account.R
+++ b/mco1-bankfx-r/tests/test_account.R
@@ -135,4 +135,4 @@ expect_error(deposit(s3,  1, "EUR"))                      # EUR deposit must als
 # ─────────────────────────────────────────────────────────────────────────────
 # Done
 # ─────────────────────────────────────────────────────────────────────────────
-cat("account tests passed\n")                           # Success banner when all assertions hold
+cat("✅ account tests passed\n")                        # Success banner when all assertions hold


### PR DESCRIPTION
## Summary
- fix the currency validator helper and provide a shared `ensure_currency()` normalizer used across the app
- align the main menu and screen prompts with the PDF specification, including new currency menus and interest table output
- add the required `docs/screenshots/` placeholder and ensure the account test banner matches the acceptance wording

## Testing
- ⚠️ `Rscript --vanilla tests/test_rates.R` *(Rscript executable is unavailable in this environment)*
- ⚠️ `Rscript --vanilla tests/test_account.R` *(Rscript executable is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b03e5af88328b912130726f164a0