### PR TITLE
Handle bracket stripping without regex escapes

### DIFF
--- a/mco1-bankfx-r/R/ui_screens.R
+++ b/mco1-bankfx-r/R/ui_screens.R
@@ -31,7 +31,8 @@ source("R/interest.R")                                                       # d
 .coerce_currency_selection <- function(input) {                                # Accept bracketed numbers or codes.
   raw <- trimws(input)                                                         # Remove stray whitespace around the input.
   raw <- gsub("[\t\r\n]", "", raw, perl = TRUE)                            # Strip control characters defensively.
-  raw <- gsub("[\[\]]", "", raw, perl = TRUE)                              # Allow entries like "[2]" from the spec transcript.
+  raw <- gsub("[", "", raw, fixed = TRUE)                                   # Allow entries like "[2]" from the spec transcript.
+  raw <- gsub("]", "", raw, fixed = TRUE)                                   # Remove closing bracket separately.
   if (!nzchar(raw)) stop("Currency selection cannot be blank.", call. = FALSE)
 
   # Try numeric index first (per spec prompt using option numbers).


### PR DESCRIPTION
## Summary
- strip square brackets from currency selections with two fixed gsub() calls to avoid problematic regex escapes

## Testing
- Rscript --vanilla app/main.R *(fails: command not found)*
- Rscript --vanilla tests/test_rates.R *(fails: command not found)*
- Rscript --vanilla tests/test_account.R *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cda678d88328b188d9f57b1122d0