### PR TITLE
Fix interactive prompts to use readline

### DIFF
--- a/mco1-bankfx-r/R/ui_screens.R
+++ b/mco1-bankfx-r/R/ui_screens.R
@@ -54,9 +54,17 @@ source("R/interest.R")                                                       # d
 # ────────────────────────────────────────────────────────────────────────────
 
 .read_line <- function(prompt) {                                             # Read a single line of raw text from stdin.
+  if (interactive()) {                                                       # readline() keeps cursor position in consoles.
+    return(readline(prompt = prompt))
+  }
+
   cat(prompt)                                                                # Show the prompt without newline suppression.
-  ln <- readLines(stdin(), 1)                                                # Read exactly one line from the console.
-  ln                                                                          # Return as character (may be empty string).
+  flush.console()                                                            # Ensure prompt appears before waiting.
+  ln <- tryCatch(                                                            # Safely attempt to read one line.
+    readLines(stdin(), 1, warn = FALSE),
+    error = function(e) character(0)
+  )
+  if (length(ln) == 0) "" else ln                                            # Gracefully handle EOF in batch mode.
 }
 
 .read_number <- function(prompt) {                                           # Read a numeric (double) from stdin with parse check.


### PR DESCRIPTION
## Summary
- switch menu input helpers to use `readline()` when interactive and guard batch mode with flushed prompts and EOF checks
- ensure UI helper `.read_line()` uses the same interactive/batch strategy so downstream prompts behave consistently
- exit gracefully when no interactive input is available instead of crashing under Rscript

## Testing
- not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8d5d3d6a88328899925c78cca1bb4