### PR TITLE
Refactor menu input handling

### DIFF
--- a/mco1-bankfx-r/app/main.R
+++ b/mco1-bankfx-r/app/main.R
@@ -31,35 +31,29 @@ print_main_menu <- function() {                                                 
   cat("[0] Exit\n")
 }
 
-read_choice <- function() {                                                     # Reads one line from stdin for the menu pick.
-  if (interactive()) {                                                          # Prefer readline() when a console is available.
-    ans <- readline(prompt = "Select option: ")                                 # Keeps cursor in place on Windows Rterm.
-  } else {                                                                      # Batch mode (e.g., Rscript): fall back to readLines
-    cat("Select option: ")                                                      # Prompt text must match the spec.
-    flush.console()                                                             # Ensure prompt is flushed before waiting for input.
-    ans <- tryCatch(                                                            # Guard against EOF/connection issues.
+prompted_read <- function(prompt) {                                             # Shared helper for readline + readLines fallback.
+  if (interactive()) {                                                          # Prefer readline() to keep prompts inline.
+    ans <- readline(prompt = prompt)                                            # readline() handles its own flushing.
+  } else {                                                                      # Batch mode (e.g., Rscript): use readLines().
+    cat(prompt)
+    flush.console()
+    ans <- tryCatch(
       readLines(stdin(), n = 1, warn = FALSE),
       error = function(e) character(0)
     )
-    if (length(ans) == 0) return(NA_character_)                                 # Signal lack of input upstream.
+    if (length(ans) == 0) return(NA_character_)                                 # No input available → signal caller.
   }
   trimws(ans)                                                                   # Return trimmed string (e.g., "1", "2", "0").
 }
 
-ask_back_to_main_menu <- function() {                                           # Asks whether to loop back to the menu.
-  if (interactive()) {                                                          # Use readline() to avoid prompt overwrite.
-    ans <- readline(prompt = "\nBack to the Main Menu (Y/N): ")                 # Exact wording per spec (note "the").
-    return(toupper(trimws(ans)) == "Y")                                         # TRUE to loop, FALSE to exit.
-  }
+read_choice <- function() {                                                     # Reads one line from stdin for the menu pick.
+  prompted_read("Select option: ")                                              # Delegate to helper for both modes.
+}
 
-  cat("\nBack to the Main Menu (Y/N): ")                                        # Batch mode prompt.
-  flush.console()                                                               # Flush for non-interactive environments.
-  ans <- tryCatch(                                                              # Attempt to read one line if available.
-    readLines(stdin(), n = 1, warn = FALSE),
-    error = function(e) character(0)
-  )
-  if (length(ans) == 0) return(FALSE)                                           # No input → treat as "No" to exit gracefully.
-  toupper(trimws(ans)) == "Y"                                                   # Normalize to uppercase.
+ask_back_to_main_menu <- function() {                                           # Asks whether to loop back to the menu.
+  ans <- prompted_read("\nBack to the Main Menu (Y/N): ")                      # Exact wording handled by readline().
+  if (is.na(ans)) return(NA)                                                    # Propagate NA when no input is available.
+  toupper(ans) == "Y"                                                           # Normalize to uppercase and compare.
 }
 
 safe_call <- function(screen_fn, state) {                                       # Wrapper: run a screen and trap errors.
@@ -82,7 +76,7 @@ main_menu <- function() {                                                       
     print_main_menu()                                                           # Show the menu.
     choice <- read_choice()                                                     # Read the user's selection as a string.
     if (is.na(choice)) {                                                        # Handle non-interactive execution without input.
-      cat("\n(No interactive input available. Run via Rterm.exe or inside R/RStudio.)\n")
+      cat("\nNo interactive input detected; exiting.\n")
       break                                                                     # Exit loop gracefully.
     }
 
@@ -100,7 +94,13 @@ main_menu <- function() {                                                       
     else if (choice == "6") state <- safe_call(screen_show_interest,     state) # 6) Show Interest Amount
     else                          cat("Invalid choice.\n")                       # Any other input → helpful message.
 
-    if (!ask_back_to_main_menu()) {                                             # After a screen, ask whether to return to menu.
+    back_to_menu <- ask_back_to_main_menu()                                     # After a screen, ask whether to return to menu.
+    if (is.na(back_to_menu)) {                                                  # Handle batch execution without further input.
+      cat("\nNo interactive input detected; exiting.\n")
+      break
+    }
+
+    if (!back_to_menu) {                                                        # After a screen, ask whether to return to menu.
       cat("Goodbye!\n")                                                         # If not, exit gracefully.
       break                                                                     # Leave the loop.
     }


### PR DESCRIPTION
## Summary
- add a shared helper to normalize menu input reading for both interactive and batch execution
- return NA when no stdin is available so the main loop can exit gracefully with a concise status message
- ensure the back-to-menu prompt uses the exact readline wording while still supporting batch mode

## Testing
- `Rscript --vanilla app/main.R` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8dcb9bf708328897f906d52accbaa