### PR TITLE
Align interest screen heading with menu wording

### DIFF
--- a/mco1-bankfx-r/R/ui_screens.R
+++ b/mco1-bankfx-r/R/ui_screens.R
@@ -169,7 +169,7 @@ screen_withdraw <- function(state) {
 # Output : ASCII table "Day | Interest | Balance" with 2-decimal formatting
 # ────────────────────────────────────────────────────────────────────────────
 screen_show_interest <- function(state) {
-  cat("\nShow Interest Amount\n")                                            # Section header per spec.
+  cat("\nShow Interest Computation\n")                                       # Section header per spec.
   cat("Account Name: ", .account_label(state), "\n", sep = "")               # Provide context consistent with PDF output.
   cat("Current Balance: ", money(get_balance_php(state)), "\n", sep = "")     # Show current balance before simulation.
   cat("Currency: PHP\n")                                                     # Balance is always maintained in PHP.


### PR DESCRIPTION
## Summary
- update the show interest screen heading to read "Show Interest Computation"

## Testing
- ⚠️ `printf "6\n1\nN\n" | Rscript app/main.R` *(fails: `Rscript` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8dca4d5288328b2b0eefe6951044a