### PR TITLE
Preserve CSV header names during ingestion

### DIFF
--- a/mco2-flood-pipeline/R/ingest.R
+++ b/mco2-flood-pipeline/R/ingest.R
@@ -40,7 +40,8 @@ ingest_csv <- function(path) {  # Main ingestion function returning tibble
     locale = locale,  # Locale configuration
     guess_max = 10000,  # Expand guessing horizon for diverse columns
     na = c("", "NA", "N/A", "null", "NULL"),  # Accepted NA tokens
-    show_col_types = FALSE  # Suppress column type printing
+    show_col_types = FALSE,  # Suppress column type printing
+    name_repair = "minimal"  # Preserve original header names (even duplicates)
   )
   if (nrow(df) == 0) {  # Ensure dataset contains rows
     stop("Input file has no data rows")  # Abort on empty dataset


### PR DESCRIPTION
## Summary
- ensure CSV ingestion keeps original column names so duplicate headers are detected

## Testing
- Rscript -e 'testthat::test_file("tests/test_ingest.R")' *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3ad7163c832881311b609629d6f7